### PR TITLE
Add compile options: '--features oniguruma' #13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,13 @@ jobs:
         if: contains(matrix.target, 'musl')
         run: |
           rustup target add ${{ matrix.target }}
-          CFLAGS="-fPIE" CC="musl-gcc -static" cargo build --verbose --release --target ${{ matrix.target }}
+          CFLAGS="-fPIE" CC="musl-gcc -static" cargo build --verbose --features oniguruma --release --target ${{ matrix.target }}
 
       - name: Compile
         if: "! contains(matrix.target, 'musl')"
         run: |
           rustup target add ${{ matrix.target }}
-          cargo build --verbose --release --target ${{ matrix.target }}
+          cargo build --verbose --features oniguruma --release --target ${{ matrix.target }}
 
       - name: Build packages
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,11 @@ jobs:
         run: |
           rustup target add ${{ matrix.target }}
           if [[ ${{ matrix.target }} =~ "musl" ]] ;then
-            CFLAGS="-fPIE" CC="musl-gcc -static" cargo build --release --verbose --target x86_64-unknown-linux-musl
+            CFLAGS="-fPIE" CC="musl-gcc -static" cargo build --features oniguruma --release --verbose --target x86_64-unknown-linux-musl
           else
-            cargo build --verbose --release --target ${{ matrix.target }}
+            cargo build --verbose --features oniguruma --release --target ${{ matrix.target }}
           fi
           mv target/${{matrix.target}}/release/teip target/release
       - name: Run tests
         timeout-minutes: 10
-        run: cargo test --verbose
+        run: cargo test --verbose --features oniguruma

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ regex = "1"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_warn"] }
 env_logger = "0.7.1"
 lazy_static = "1.4.0"
-onig = "6"
+onig = { version = "6", optional = true }
 
 [dev-dependencies]
 assert_cmd = "1.0.1"
@@ -27,3 +27,7 @@ criterion = "0.3.2"
 [[bench]]
 name = "cmdbench"
 harness = false
+
+[features]
+default = []
+oniguruma = ["onig"]

--- a/src/impure/onig.rs
+++ b/src/impure/onig.rs
@@ -5,10 +5,15 @@ pub type Regex = onig::Regex;
 pub type RegexOptions = onig::RegexOptions;
 pub type Syntax = onig::Syntax;
 
-use super::super::{errors, PipeIntercepter, DEFAULT_CAP, trim_eol, msg_error};
+use super::super::{errors, PipeIntercepter, DEFAULT_CAP, trim_eol, msg_error, error_exit};
 
 pub fn new_regex() -> Regex {
     Regex::new("").unwrap()
+}
+
+pub fn new_option_multiline_regex(s: &str) -> Regex {
+    Regex::with_options(s, RegexOptions::REGEX_OPTION_MULTILINE, Syntax::default())
+        .unwrap_or_else(|e| error_exit(&e.to_string()))
 }
 
 /// Handles regex onig ( -g -G )

--- a/src/impure/onig.rs
+++ b/src/impure/onig.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "oniguruma")]
 use std::io::{self, BufRead};
 
 #[cfg(feature = "oniguruma")]
@@ -11,12 +12,12 @@ pub type Syntax = onig::Syntax;
 
 #[cfg(not(feature = "oniguruma"))]
 pub type Regex = i64;
-#[cfg(not(feature = "oniguruma"))]
-pub type RegexOptions = i64;
-#[cfg(not(feature = "oniguruma"))]
-pub type Syntax = i64;
 
+#[cfg(feature = "oniguruma")]
 use super::super::{errors, PipeIntercepter, DEFAULT_CAP, trim_eol, msg_error, error_exit};
+
+#[cfg(not(feature = "oniguruma"))]
+use super::super::{errors, PipeIntercepter};
 
 #[cfg(feature = "oniguruma")]
 pub fn new_regex() -> Regex {
@@ -35,7 +36,7 @@ pub fn new_option_multiline_regex(s: &str) -> Regex {
 }
 
 #[cfg(not(feature = "oniguruma"))]
-pub fn new_option_multiline_regex(s: &str) -> Regex {
+pub fn new_option_multiline_regex(_s: &str) -> Regex {
     1
 }
 
@@ -46,7 +47,7 @@ pub fn new_option_none_regex(s: &str) -> Regex {
 }
 
 #[cfg(not(feature = "oniguruma"))]
-pub fn new_option_none_regex(s: &str) -> Regex {
+pub fn new_option_none_regex(_s: &str) -> Regex {
     1
 }
 
@@ -96,10 +97,10 @@ pub fn regex_onig_proc(
 #[cfg(not(feature = "oniguruma"))]
 /// Handles regex onig ( -g -G )
 pub fn regex_onig_proc(
-    ch: &mut PipeIntercepter,
-    line: &Vec<u8>,
-    re: &Regex,
-    invert: bool,
+    _ch: &mut PipeIntercepter,
+    _line: &Vec<u8>,
+    _re: &Regex,
+    _invert: bool,
 ) -> Result<(), errors::TokenSendError> {
     Ok(())
 }
@@ -148,10 +149,10 @@ pub fn regex_onig_line_proc(
 
 #[cfg(not(feature = "oniguruma"))]
 pub fn regex_onig_line_proc(
-    ch: &mut PipeIntercepter,
-    re: &Regex,
-    invert: bool,
-    line_end: u8,
+    _ch: &mut PipeIntercepter,
+    _re: &Regex,
+    _invert: bool,
+    _line_end: u8,
 ) -> Result<(), errors::TokenSendError> {
     Ok(())
 }

--- a/src/impure/onig.rs
+++ b/src/impure/onig.rs
@@ -1,0 +1,45 @@
+use super::super::errors;
+use super::super::PipeIntercepter;
+
+/// Handles regex onig ( -g -G )
+pub fn regex_onig_proc(
+    ch: &mut PipeIntercepter,
+    line: &Vec<u8>,
+    re: &onig::Regex,
+    invert: bool,
+) -> Result<(), errors::TokenSendError> {
+    let line = String::from_utf8_lossy(&line).to_string();
+    let mut left_index = 0;
+    let mut right_index;
+    for cap in re.find_iter(&line) {
+        right_index = cap.0;
+        let unmatched = &line[left_index..right_index];
+        let matched = &line[cap.0..cap.1];
+        // Ignore empty string.
+        // Regex "*" matches empty, but , in most situations,
+        // handling empty string is not helpful for users.
+        if !unmatched.is_empty() {
+            if !invert {
+                ch.send_msg(unmatched.to_string())?;
+            } else {
+                ch.send_pipe(unmatched.to_string())?;
+            }
+        }
+        if !invert {
+            ch.send_pipe(matched.to_string())?;
+        } else {
+            ch.send_msg(matched.to_string())?;
+        }
+        left_index = cap.1;
+    }
+    if left_index < line.len() {
+        let unmatched = &line[left_index..line.len()];
+        if !invert {
+            ch.send_msg(unmatched.to_string())?;
+        } else {
+            ch.send_pipe(unmatched.to_string())?;
+        }
+    }
+    Ok(())
+}
+

--- a/src/impure/onig.rs
+++ b/src/impure/onig.rs
@@ -1,5 +1,10 @@
 use std::io::{self, BufRead};
 
+use onig::{self};
+pub type Regex = onig::Regex;
+pub type RegexOptions = onig::RegexOptions;
+pub type Syntax = onig::Syntax;
+
 use super::super::{errors, PipeIntercepter, DEFAULT_CAP, trim_eol, msg_error};
 
 /// Handles regex onig ( -g -G )

--- a/src/impure/onig.rs
+++ b/src/impure/onig.rs
@@ -16,6 +16,11 @@ pub fn new_option_multiline_regex(s: &str) -> Regex {
         .unwrap_or_else(|e| error_exit(&e.to_string()))
 }
 
+pub fn new_option_none_regex(s: &str) -> Regex {
+    Regex::with_options(s, RegexOptions::REGEX_OPTION_NONE, Syntax::default())
+        .unwrap_or_else(|e| error_exit(&e.to_string()))
+}
+
 /// Handles regex onig ( -g -G )
 pub fn regex_onig_proc(
     ch: &mut PipeIntercepter,

--- a/src/impure/onig.rs
+++ b/src/impure/onig.rs
@@ -7,11 +7,15 @@ pub type Syntax = onig::Syntax;
 
 use super::super::{errors, PipeIntercepter, DEFAULT_CAP, trim_eol, msg_error};
 
+pub fn new_regex() -> Regex {
+    Regex::new("").unwrap()
+}
+
 /// Handles regex onig ( -g -G )
 pub fn regex_onig_proc(
     ch: &mut PipeIntercepter,
     line: &Vec<u8>,
-    re: &onig::Regex,
+    re: &Regex,
     invert: bool,
 ) -> Result<(), errors::TokenSendError> {
     let line = String::from_utf8_lossy(&line).to_string();
@@ -51,7 +55,7 @@ pub fn regex_onig_proc(
 
 pub fn regex_onig_line_proc(
     ch: &mut PipeIntercepter,
-    re: &onig::Regex,
+    re: &Regex,
     invert: bool,
     line_end: u8,
 ) -> Result<(), errors::TokenSendError> {

--- a/src/impure/onig.rs
+++ b/src/impure/onig.rs
@@ -1,26 +1,56 @@
 use std::io::{self, BufRead};
 
+#[cfg(feature = "oniguruma")]
 use onig::{self};
+#[cfg(feature = "oniguruma")]
 pub type Regex = onig::Regex;
+#[cfg(feature = "oniguruma")]
 pub type RegexOptions = onig::RegexOptions;
+#[cfg(feature = "oniguruma")]
 pub type Syntax = onig::Syntax;
+
+#[cfg(not(feature = "oniguruma"))]
+pub type Regex = i64;
+#[cfg(not(feature = "oniguruma"))]
+pub type RegexOptions = i64;
+#[cfg(not(feature = "oniguruma"))]
+pub type Syntax = i64;
 
 use super::super::{errors, PipeIntercepter, DEFAULT_CAP, trim_eol, msg_error, error_exit};
 
+#[cfg(feature = "oniguruma")]
 pub fn new_regex() -> Regex {
     Regex::new("").unwrap()
 }
 
+#[cfg(not(feature = "oniguruma"))]
+pub fn new_regex() -> Regex {
+    1
+}
+
+#[cfg(feature = "oniguruma")]
 pub fn new_option_multiline_regex(s: &str) -> Regex {
     Regex::with_options(s, RegexOptions::REGEX_OPTION_MULTILINE, Syntax::default())
         .unwrap_or_else(|e| error_exit(&e.to_string()))
 }
 
+#[cfg(not(feature = "oniguruma"))]
+pub fn new_option_multiline_regex(s: &str) -> Regex {
+    1
+}
+
+#[cfg(feature = "oniguruma")]
 pub fn new_option_none_regex(s: &str) -> Regex {
     Regex::with_options(s, RegexOptions::REGEX_OPTION_NONE, Syntax::default())
         .unwrap_or_else(|e| error_exit(&e.to_string()))
 }
 
+#[cfg(not(feature = "oniguruma"))]
+pub fn new_option_none_regex(s: &str) -> Regex {
+    1
+}
+
+#[cfg(feature = "oniguruma")]
 /// Handles regex onig ( -g -G )
 pub fn regex_onig_proc(
     ch: &mut PipeIntercepter,
@@ -63,6 +93,18 @@ pub fn regex_onig_proc(
     Ok(())
 }
 
+#[cfg(not(feature = "oniguruma"))]
+/// Handles regex onig ( -g -G )
+pub fn regex_onig_proc(
+    ch: &mut PipeIntercepter,
+    line: &Vec<u8>,
+    re: &Regex,
+    invert: bool,
+) -> Result<(), errors::TokenSendError> {
+    Ok(())
+}
+
+#[cfg(feature = "oniguruma")]
 pub fn regex_onig_line_proc(
     ch: &mut PipeIntercepter,
     re: &Regex,
@@ -104,3 +146,12 @@ pub fn regex_onig_line_proc(
     Ok(())
 }
 
+#[cfg(not(feature = "oniguruma"))]
+pub fn regex_onig_line_proc(
+    ch: &mut PipeIntercepter,
+    re: &Regex,
+    invert: bool,
+    line_end: u8,
+) -> Result<(), errors::TokenSendError> {
+    Ok(())
+}

--- a/src/impure/onig.rs
+++ b/src/impure/onig.rs
@@ -1,57 +1,26 @@
-#[cfg(feature = "oniguruma")]
 use std::io::{self, BufRead};
 
-#[cfg(feature = "oniguruma")]
 use onig::{self};
-#[cfg(feature = "oniguruma")]
 pub type Regex = onig::Regex;
-#[cfg(feature = "oniguruma")]
 pub type RegexOptions = onig::RegexOptions;
-#[cfg(feature = "oniguruma")]
 pub type Syntax = onig::Syntax;
 
-#[cfg(not(feature = "oniguruma"))]
-pub type Regex = i64;
-
-#[cfg(feature = "oniguruma")]
 use super::super::{errors, PipeIntercepter, DEFAULT_CAP, trim_eol, msg_error, error_exit};
 
-#[cfg(not(feature = "oniguruma"))]
-use super::super::{errors, PipeIntercepter};
-
-#[cfg(feature = "oniguruma")]
 pub fn new_regex() -> Regex {
     Regex::new("").unwrap()
 }
 
-#[cfg(not(feature = "oniguruma"))]
-pub fn new_regex() -> Regex {
-    1
-}
-
-#[cfg(feature = "oniguruma")]
 pub fn new_option_multiline_regex(s: &str) -> Regex {
     Regex::with_options(s, RegexOptions::REGEX_OPTION_MULTILINE, Syntax::default())
         .unwrap_or_else(|e| error_exit(&e.to_string()))
 }
 
-#[cfg(not(feature = "oniguruma"))]
-pub fn new_option_multiline_regex(_s: &str) -> Regex {
-    1
-}
-
-#[cfg(feature = "oniguruma")]
 pub fn new_option_none_regex(s: &str) -> Regex {
     Regex::with_options(s, RegexOptions::REGEX_OPTION_NONE, Syntax::default())
         .unwrap_or_else(|e| error_exit(&e.to_string()))
 }
 
-#[cfg(not(feature = "oniguruma"))]
-pub fn new_option_none_regex(_s: &str) -> Regex {
-    1
-}
-
-#[cfg(feature = "oniguruma")]
 /// Handles regex onig ( -g -G )
 pub fn regex_onig_proc(
     ch: &mut PipeIntercepter,
@@ -94,18 +63,6 @@ pub fn regex_onig_proc(
     Ok(())
 }
 
-#[cfg(not(feature = "oniguruma"))]
-/// Handles regex onig ( -g -G )
-pub fn regex_onig_proc(
-    _ch: &mut PipeIntercepter,
-    _line: &Vec<u8>,
-    _re: &Regex,
-    _invert: bool,
-) -> Result<(), errors::TokenSendError> {
-    Ok(())
-}
-
-#[cfg(feature = "oniguruma")]
 pub fn regex_onig_line_proc(
     ch: &mut PipeIntercepter,
     re: &Regex,
@@ -144,15 +101,5 @@ pub fn regex_onig_line_proc(
             Err(e) => msg_error(&e.to_string()),
         }
     }
-    Ok(())
-}
-
-#[cfg(not(feature = "oniguruma"))]
-pub fn regex_onig_line_proc(
-    _ch: &mut PipeIntercepter,
-    _re: &Regex,
-    _invert: bool,
-    _line_end: u8,
-) -> Result<(), errors::TokenSendError> {
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,7 +379,7 @@ fn main() {
 
     let mut regex_mode = String::new();
     let mut regex = Regex::new("").unwrap();
-    let mut regex_onig = impure::onig::Regex::new("").unwrap();
+    let mut regex_onig = impure::onig::new_regex();
     let mut line_end = b'\n';
     let mut single_token_per_line = false;
     let mut ch: PipeIntercepter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -423,8 +423,7 @@ fn main() {
                 impure::onig::new_option_multiline_regex(&args.get_str("-g"));
         } else {
             regex_onig =
-                impure::onig::Regex::with_options(&args.get_str("-g"), impure::onig::RegexOptions::REGEX_OPTION_NONE, impure::onig::Syntax::default())
-                    .unwrap_or_else(|e| error_exit(&e.to_string()));
+                impure::onig::new_option_none_regex(&args.get_str("-g"));
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -420,8 +420,7 @@ fn main() {
     } else {
         if flag_zero {
             regex_onig =
-                impure::onig::Regex::with_options(&args.get_str("-g"), impure::onig::RegexOptions::REGEX_OPTION_MULTILINE, impure::onig::Syntax::default())
-                .unwrap_or_else(|e| error_exit(&e.to_string()));
+                impure::onig::new_option_multiline_regex(&args.get_str("-g"));
         } else {
             regex_onig =
                 impure::onig::Regex::with_options(&args.get_str("-g"), impure::onig::RegexOptions::REGEX_OPTION_NONE, impure::onig::Syntax::default())

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ mod list {
     pub mod ranges;
 }
 mod impure {
-    #[cfg(feature = "oniguruma")]
     pub mod onig;
 }
 mod errors;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod list {
     pub mod ranges;
 }
 mod impure {
+    #[cfg(feature = "oniguruma")]
     pub mod onig;
 }
 mod errors;
@@ -21,7 +22,6 @@ use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::process::{Command, Stdio};
 use std::sync::mpsc::{self, Sender};
 use std::thread::{self, JoinHandle};
-use onig::{self};
 use token::Token;
 
 const CMD: &'static str = env!("CARGO_PKG_NAME"); // "teip"
@@ -379,7 +379,7 @@ fn main() {
 
     let mut regex_mode = String::new();
     let mut regex = Regex::new("").unwrap();
-    let mut regex_onig = onig::Regex::new("").unwrap();
+    let mut regex_onig = impure::onig::Regex::new("").unwrap();
     let mut line_end = b'\n';
     let mut single_token_per_line = false;
     let mut ch: PipeIntercepter;
@@ -420,11 +420,11 @@ fn main() {
     } else {
         if flag_zero {
             regex_onig =
-                onig::Regex::with_options(&args.get_str("-g"), onig::RegexOptions::REGEX_OPTION_MULTILINE, onig::Syntax::default())
+                impure::onig::Regex::with_options(&args.get_str("-g"), impure::onig::RegexOptions::REGEX_OPTION_MULTILINE, impure::onig::Syntax::default())
                 .unwrap_or_else(|e| error_exit(&e.to_string()));
         } else {
             regex_onig =
-                onig::Regex::with_options(&args.get_str("-g"), onig::RegexOptions::REGEX_OPTION_NONE, onig::Syntax::default())
+                impure::onig::Regex::with_options(&args.get_str("-g"), impure::onig::RegexOptions::REGEX_OPTION_NONE, impure::onig::Syntax::default())
                     .unwrap_or_else(|e| error_exit(&e.to_string()));
         }
     }

--- a/src/pure/onig.rs
+++ b/src/pure/onig.rs
@@ -1,0 +1,33 @@
+pub type Regex = i64;
+use super::super::{errors, PipeIntercepter};
+
+pub fn new_regex() -> Regex {
+    1
+}
+
+pub fn new_option_multiline_regex(_s: &str) -> Regex {
+    1
+}
+
+pub fn new_option_none_regex(_s: &str) -> Regex {
+    1
+}
+
+/// Handles regex onig ( -g -G )
+pub fn regex_onig_proc(
+    _ch: &mut PipeIntercepter,
+    _line: &Vec<u8>,
+    _re: &Regex,
+    _invert: bool,
+) -> Result<(), errors::TokenSendError> {
+    Ok(())
+}
+
+pub fn regex_onig_line_proc(
+    _ch: &mut PipeIntercepter,
+    _re: &Regex,
+    _invert: bool,
+    _line_end: u8,
+) -> Result<(), errors::TokenSendError> {
+    Ok(())
+}

--- a/src/pure/onig.rs
+++ b/src/pure/onig.rs
@@ -1,5 +1,5 @@
 pub type Regex = i64;
-use super::super::{errors, PipeIntercepter};
+use super::super::{errors, PipeIntercepter, CMD};
 
 pub fn new_regex() -> Regex {
     1
@@ -20,6 +20,7 @@ pub fn regex_onig_proc(
     _re: &Regex,
     _invert: bool,
 ) -> Result<(), errors::TokenSendError> {
+    eprintln!("{}: This build is not enabled 'oniguruma'", CMD);
     Ok(())
 }
 
@@ -29,5 +30,6 @@ pub fn regex_onig_line_proc(
     _invert: bool,
     _line_end: u8,
 ) -> Result<(), errors::TokenSendError> {
+    eprintln!("{}: This build is not enabled 'oniguruma'", CMD);
     Ok(())
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -172,6 +172,7 @@ mod cmdtest {
     }
 
     #[test]
+    #[cfg(feature = "oniguruma")]
     fn test_onig() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         cmd.args(&["-Gog", "\\d+(?=D)", "sed", "s/./@/g"])
@@ -181,6 +182,7 @@ mod cmdtest {
     }
 
     #[test]
+    #[cfg(feature = "oniguruma")]
     fn test_onig_invert() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         cmd.args(&["-v","-Gog","\\d+(?=D)", "sed", "s/./@/g"])
@@ -190,6 +192,7 @@ mod cmdtest {
     }
 
     #[test]
+    #[cfg(feature = "oniguruma")]
     fn test_onig_null() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         // Use perl -0 instead of sed -z because BSD does not support it.
@@ -209,6 +212,7 @@ mod cmdtest {
     }
 
     #[test]
+    #[cfg(feature = "oniguruma")]
     fn test_onig_null_invert() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         // Use perl -0 instead of sed -z because BSD does not support it.
@@ -219,6 +223,7 @@ mod cmdtest {
     }
 
     #[test]
+    #[cfg(feature = "oniguruma")]
     fn test_onig_multiple() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         cmd.args(&["-Gog", "C\\K\\d+(?=D)", "sed", "s/./@/g"])
@@ -228,6 +233,7 @@ mod cmdtest {
     }
 
     #[test]
+    #[cfg(feature = "oniguruma")]
     fn test_solid_onig() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         cmd.args(&["-s", "-Gog", "2", "sed", "s/./A/"])
@@ -237,6 +243,7 @@ mod cmdtest {
     }
 
     #[test]
+    #[cfg(feature = "oniguruma")]
     fn test_solid_onig_invert() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         cmd.args(&["-s", "-Gog", "\\d+", "-v", "tr", "[:upper:]", "[:lower:]"])
@@ -246,6 +253,7 @@ mod cmdtest {
     }
 
     #[test]
+    #[cfg(feature = "oniguruma")]
     fn test_solid_onig_null_invert() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         cmd.args(&["-sv","-Gog", "\\d+", "tr", "[:upper:]", "[:lower:]"])
@@ -255,6 +263,7 @@ mod cmdtest {
     }
 
     #[test]
+    #[cfg(feature = "oniguruma")]
     fn test_solid_onig_null() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         cmd.args(&[
@@ -272,6 +281,7 @@ mod cmdtest {
     }
 
     #[test]
+    #[cfg(feature = "oniguruma")]
     fn test_solid_onig_null2() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         cmd.args(&["-sz", "-Gog", "(..\\n..|F.G)", "--", "tr", "-dc", "."])


### PR DESCRIPTION
# 概要

* `--features oniguruma` で oniguruma を有効にしてビルドできるように変更
  * デフォルトでは oniguruma が無効になってしまうため、CIのビルドオプションに `--features oniguruma` を追加

# 内容

* `impure::onig` と `pure::onig` モジュールを追加
* それぞれは同じ型、同じ関数を定義されている必要があります
* main.rs からは直接外部ライブラリのonigモジュールを呼び出さず、 `impure::onig` か `pure::onig` に隠蔽されたonigの機能を呼び出します

# 補足

以下はビルド時の出力です。

```bash
⟩ cargo build
   Compiling proc-macro2 v1.0.18
   Compiling memchr v2.3.3
   Compiling unicode-xid v0.2.1
   Compiling syn v1.0.33
   Compiling serde_derive v1.0.114
   Compiling libc v0.2.71
   Compiling lazy_static v1.4.0
   Compiling regex-syntax v0.6.18
   Compiling serde v1.0.114
   Compiling log v0.4.8
   Compiling quick-error v1.2.3
   Compiling cfg-if v0.1.10
   Compiling strsim v0.9.3
   Compiling termcolor v1.1.0
   Compiling thread_local v1.0.1
   Compiling humantime v1.3.0
   Compiling quote v1.0.7
   Compiling aho-corasick v0.7.13
   Compiling atty v0.2.14
   Compiling regex v1.3.9
   Compiling env_logger v0.7.1
   Compiling docopt v1.1.0
   Compiling teip v1.2.0 (/home/vagrant/src/github.com/jiro4989/teip)
    Finished dev [unoptimized + debuginfo] target(s) in 36.98s

⟩ cargo build --features oniguruma
   Compiling cc v1.0.55
   Compiling version_check v0.9.2
   Compiling glob v0.3.0
   Compiling bitflags v1.2.1
   Compiling unicode-width v0.1.7
   Compiling strsim v0.8.0
   Compiling vec_map v0.8.2
   Compiling ansi_term v0.11.0
   Compiling bindgen v0.53.3
   Compiling shlex v0.1.1
   Compiling lazycell v1.2.1
   Compiling rustc-hash v1.1.0
   Compiling peeking_take_while v0.1.2
   Compiling pkg-config v0.3.17
   Compiling libloading v0.5.2
   Compiling nom v5.1.2
   Compiling clang-sys v0.29.3
   Compiling textwrap v0.11.0
   Compiling which v3.1.1
   Compiling clap v2.33.1
   Compiling cexpr v0.4.0
   Compiling onig_sys v69.5.0
   Compiling onig v6.0.0
   Compiling teip v1.2.0 (/home/vagrant/src/github.com/jiro4989/teip)
    Finished dev [unoptimized + debuginfo] target(s) in 36.64s
```

`--features oniguruma` を有効にしたほうだけ `onig` をコンパイルしています。
以下はコマンドの実行結果です。

```bash
⟩ cargo build
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s

⟩ echo '寿司' | ./target/debug/teip -oGg '寿'
teip: This build is not enabled 'oniguruma'
```

```bash
⟩ cargo build --features oniguruma
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s

⟩ echo '寿司' | ./target/debug/teip -oGg '寿'
[寿]司
```