### PR TITLE
Replace docopt with structopt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ env_logger = "0.7.1"
 lazy_static = "1.4.0"
 onig = { version = "6", optional = true }
 structopt = "0.3.15"
-clap = { version = "2.33", features = ["yaml"] }
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ log = { version = "0.4", features = ["max_level_trace", "release_max_level_warn"
 env_logger = "0.7.1"
 lazy_static = "1.4.0"
 onig = { version = "6", optional = true }
+structopt = "0.3.15"
+clap = { version = "2.33", features = ["yaml"] }
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/benches/cmdbench.rs
+++ b/benches/cmdbench.rs
@@ -64,8 +64,6 @@ fn onig_double(lap: usize) {
     let _ = child.wait_with_output();
 }
 
-
-
 fn field_double(lap: usize) {
     let mut child = Command::new(CMD)
         .stdin(Stdio::piped())

--- a/src/impure/onig.rs
+++ b/src/impure/onig.rs
@@ -5,7 +5,7 @@ pub type Regex = onig::Regex;
 pub type RegexOptions = onig::RegexOptions;
 pub type Syntax = onig::Syntax;
 
-use super::super::{errors, PipeIntercepter, DEFAULT_CAP, trim_eol, msg_error, error_exit};
+use super::super::{error_exit, errors, msg_error, trim_eol, PipeIntercepter, DEFAULT_CAP};
 
 pub fn new_regex() -> Regex {
     Regex::new("").unwrap()
@@ -87,7 +87,7 @@ pub fn regex_onig_line_proc(
                         } else {
                             ch.send_pipe(line.to_string())?;
                         }
-                    },
+                    }
                     None => {
                         if invert {
                             ch.send_pipe(line.to_string())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,7 +318,6 @@ lazy_static! {
 
 #[derive(StructOpt, Debug)]
 #[structopt(
-    author,
     about = "Allow the command handle selected parts of the standard input, and bypass other parts."
 )]
 struct Args {

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,34 +308,6 @@ impl Drop for PipeIntercepter {
 }
 
 lazy_static! {
-    static ref USAGE: String = format!(
-        "
-Allow the command handle selected parts of the standard input, and bypass other parts.
-
-Usage:
-  {cmd} -g <pattern> [-oGsvz] [--] [<command>...]
-  {cmd} -f <list> [-d <delimiter> | -D <pattern>] [-svz] [--] [<command>...]
-  {cmd} -c <list> [-svz] [--] [<command>...]
-  {cmd} -l <list> [-svz] [--] [<command>...]
-  {cmd} --help | --version
-
-Options:
-  --help          Display this help and exit
-  --version       Show version and exit
-  -g <pattern>    Select lines that match the regular expression <pattern>
-  -o              -g selects only matched parts
-  -G              -g adopts Oniguruma regular expressions
-  -f <list>       Select only these white-space separated fields
-  -d <delimiter>  Use <delimiter> for field delimiter of -f
-  -D <pattern>    Use regular expression <pattern> for field delimiter of -f
-  -c <list>       Select only these characters
-  -l <list>       Select only these lines
-  -s              Execute command for each selected part
-  -v              Invert the sense of selecting
-  -z              Line delimiter is NUL instead of newline
-",
-        cmd = CMD
-    );
     static ref REGEX_WS: Regex = Regex::new("\\s+").unwrap();
     static ref DEFAULT_HIGHLIGHT: String = match env::var("TEIP_HIGHLIGHT") {
         Ok(v) => v,

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,7 +347,17 @@ Options:
 
 use structopt::StructOpt;
 
+const PKG_NAME: &str = env!("CARGO_PKG_NAME");
+const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+const PKG_AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
+
 #[derive(StructOpt, Debug)]
+#[structopt(
+    name = PKG_NAME,
+    version = PKG_VERSION,
+    author = PKG_AUTHORS,
+    about = "Allow the command handle selected parts of the standard input, and bypass other parts.",
+)]
 struct Args {
     #[structopt(short = "g")]
     regex: Option<String>,
@@ -381,13 +391,7 @@ fn main() {
     env_logger::init();
 
     // ***** Parse options and prepare configures *****
-    let matches = App::new(env!("CARGO_PKG_NAME"))
-        .version(env!("CARGO_PKG_VERSION"))
-        .author(env!("CARGO_PKG_AUTHORS"))
-        .about("Allow the command handle selected parts of the standard input, and bypass other parts.");
-
     let args: Args = Args::from_args();
-
 
     debug!("{:?}", args);
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -67,7 +67,7 @@ mod cmdtest {
     fn test_regex_only_null_invert() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         // Use perl -0 instead of sed -z because BSD does not support it.
-        cmd.args(&["-zv","-og", "^...", "tr", "[:alnum:]", "@"])
+        cmd.args(&["-zv", "-og", "^...", "tr", "[:alnum:]", "@"])
             .write_stdin("ABC123EFG\0HIJKLM456")
             .assert()
             .stdout("ABC@@@@@@\0HIJ@@@@@@");
@@ -121,7 +121,7 @@ mod cmdtest {
     #[test]
     fn test_solid_regex_only_null_invert() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-        cmd.args(&["-sv","-og", "\\d+", "tr", "[:upper:]", "[:lower:]"])
+        cmd.args(&["-sv", "-og", "\\d+", "tr", "[:upper:]", "[:lower:]"])
             .write_stdin("ABC123EFG\0\nHIJKLM456")
             .assert()
             .stdout("abc123efg\0\nhijklm456");
@@ -185,7 +185,7 @@ mod cmdtest {
     #[cfg(feature = "oniguruma")]
     fn test_onig_invert() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-        cmd.args(&["-v","-Gog","\\d+(?=D)", "sed", "s/./@/g"])
+        cmd.args(&["-v", "-Gog", "\\d+(?=D)", "sed", "s/./@/g"])
             .write_stdin("ABC123DEF456\n")
             .assert()
             .stdout("@@@123@@@@@@\n");
@@ -216,7 +216,7 @@ mod cmdtest {
     fn test_onig_null_invert() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         // Use perl -0 instead of sed -z because BSD does not support it.
-        cmd.args(&["-zv","-Gog", "^...", "tr", "[:alnum:]", "@"])
+        cmd.args(&["-zv", "-Gog", "^...", "tr", "[:alnum:]", "@"])
             .write_stdin("ABC123EFG\0HIJKLM456")
             .assert()
             .stdout("ABC@@@@@@\0HIJ@@@@@@");
@@ -256,7 +256,7 @@ mod cmdtest {
     #[cfg(feature = "oniguruma")]
     fn test_solid_onig_null_invert() {
         let mut cmd = assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-        cmd.args(&["-sv","-Gog", "\\d+", "tr", "[:upper:]", "[:lower:]"])
+        cmd.args(&["-sv", "-Gog", "\\d+", "tr", "[:upper:]", "[:lower:]"])
             .write_stdin("ABC123EFG\0\nHIJKLM456")
             .assert()
             .stdout("abc123efg\0\nhijklm456");


### PR DESCRIPTION
Fix #16 

docoptをstructoptをつかって置き換えてみました。
ただし、現状だとヘルプメッセージが以下のように置き換わってしまいます。
```
teip 1.2.1
Yasuhiro Yamada <yamadagrep@gmail.com>
Allow the command handle selected parts of the standard input, and bypass other parts.

USAGE:
    teip [FLAGS] [OPTIONS] [command]...

FLAGS:
    -h, --help       Prints help information
    -v               Invert the sense of selecting
    -G               -g adopts Oniguruma regular expressions
    -o               -g selects only matched parts
    -s               Execute command for each selected part
    -V, --version    Prints version information
    -z               Line delimiter is NUL instead of newline

OPTIONS:
    -c <char list>                Select only these characters
    -d <delimiter>                Use <delimiter> for field delimiter of -f
    -D <delimiter pattern>        Use regular expression <pattern> for field delimiter of -f
    -l <line list>                Select only these lines
    -f <list>                     Select only these white-space separated fields
    -g <pattern>                  Select lines that match the regular expression <pattern>

ARGS:
    <command>...    

```