### PR TITLE
checkout@v2 to checkout@v3

### DIFF
--- a/.github/workflows/bench-mem.yml
+++ b/.github/workflows/bench-mem.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "contains(github.event.head_commit.message, '[bench]') || contains(github.event.head_commit.message, 'Bump version')"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: cargo build --release
     - name: Benchmark for each functions
@@ -43,7 +43,7 @@ jobs:
           - name: mem_usage_one_third
             cmd: teip -e 'awk "NR % 3 == 0 {print NR}"' -- sed 's/./@/g' < test_secure
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/bench-mem_x5.yml
+++ b/.github/workflows/bench-mem_x5.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "contains(github.event.head_commit.message, '[bench]') || contains(github.event.head_commit.message, 'Bump version')"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: cargo build --release
     - name: Benchmark for each functions
@@ -43,7 +43,7 @@ jobs:
           - name: mem_usage_one_third
             cmd: teip -e 'awk "NR % 3 == 0 {print NR}"' -- sed 's/./@/g' < test_secure
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/bench-without-teip.yml
+++ b/.github/workflows/bench-without-teip.yml
@@ -20,7 +20,7 @@ jobs:
     if: "contains(github.event.head_commit.message, '[bench-spec]')"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
         sudo apt-get install valgrind

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "contains(github.event.head_commit.message, '[bench]')"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: cargo build --release
     - name: Benchmark for each functions
@@ -43,7 +43,7 @@ jobs:
             # same as: awk '{gsub(".","@",$2);print}' FS=, OFS=, < test.csv
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
             target: x86_64-apple-darwin
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install musl-gcc if required
         if: contains(matrix.target, 'musl')
         run: |

--- a/.github/workflows/test_win.yml
+++ b/.github/workflows/test_win.yml
@@ -26,7 +26,7 @@ jobs:
             ext: exe
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build the release target
         run: |
           rustup target add ${{ matrix.target }}


### PR DESCRIPTION
Due to Node.js 12 deprecation.
checkout@v3 is recommended.
https://github.com/actions/checkout

GitHub issue #45