### PR TITLE
Fix RPM digest compatibility for Fedora 43

### DIFF
--- a/.github/dockerfiles/Dockerfile.aarch64
+++ b/.github/dockerfiles/Dockerfile.aarch64
@@ -1,3 +1,3 @@
-FROM arm64v8/almalinux:9
+FROM almalinux:9
 RUN dnf install -y rpm-build redhat-rpm-config rpmdevtools \
     && dnf clean all

--- a/.github/dockerfiles/Dockerfile.aarch64
+++ b/.github/dockerfiles/Dockerfile.aarch64
@@ -1,2 +1,3 @@
-FROM arm64v8/centos:7
-RUN yum install -y rpm-build redhat-rpm-config rpmdevtools
+FROM arm64v8/almalinux:9
+RUN dnf install -y rpm-build redhat-rpm-config rpmdevtools \
+    && dnf clean all

--- a/.github/dockerfiles/Dockerfile.x86_64
+++ b/.github/dockerfiles/Dockerfile.x86_64
@@ -1,2 +1,3 @@
-FROM centos:7
-RUN yum install -y rpm-build redhat-rpm-config rpmdevtools
+FROM almalinux:9
+RUN dnf install -y rpm-build redhat-rpm-config rpmdevtools \
+    && dnf clean all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,8 @@ jobs:
           esac;
 
           cat > "${RPM_BUILD}/SPECS/template.spec" <<EOF
+          %global _binary_filedigest_algorithm 10
+          %global _source_filedigest_algorithm 10
           Name:       ${PROJECT_NAME}
           Summary:    Masking tape to help commands "do one thing well"
           Version:    ${PROJECT_VERSION}
@@ -219,6 +221,15 @@ jobs:
           ## Generate sha256
           echo "$( sha256sum "$BIN_NAME" | awk '{print $1}' )" > "${BIN_NAME}.sha256"
           sudo cp -l "${BIN_NAME}" "${BIN_NAME}.sha256" "${{ env.RELEASE_DIR }}"
+
+      - name: Verify rpm on Fedora 43
+        if: matrix.ext == 'rpm'
+        run: |
+          BIN_NAME="teip-${{ steps.vars.outputs.ver }}.${{ matrix.target }}.rpm"
+          sudo docker run --rm -v "$PWD":/work -w /work fedora:43 sh -lc '
+            dnf install -y --nogpgcheck /work/'"$BIN_NAME"'
+            rpm -Kv /work/'"$BIN_NAME"'
+          '
 
       - name: Create Debian package
         id: deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,8 +211,12 @@ jobs:
 
           ## Build
           sudo apt-get update && sudo apt-get install -y qemu-user-static
-          docker build -t ${RPM_ARCH}-rpm-builder -f .github/dockerfiles/Dockerfile.${RPM_ARCH} .
-          sudo docker run --rm -v "$PWD/$RPM_BUILD":/root/rpmbuild ${RPM_ARCH}-rpm-builder \
+          DOCKER_PLATFORM=
+          if [[ "${RPM_ARCH}" == "aarch64" ]]; then
+            DOCKER_PLATFORM="--platform linux/arm64"
+          fi
+          docker build ${DOCKER_PLATFORM} -t ${RPM_ARCH}-rpm-builder -f .github/dockerfiles/Dockerfile.${RPM_ARCH} .
+          sudo docker run ${DOCKER_PLATFORM} --rm -v "$PWD/$RPM_BUILD":/root/rpmbuild ${RPM_ARCH}-rpm-builder \
             rpmbuild --undefine=_disable_source_fetch -ba /root/rpmbuild/SPECS/template.spec
 
           BIN_NAME="teip-${{ steps.vars.outputs.ver }}.${{ matrix.target }}.rpm"

--- a/.github/workflows/rpm-verify.yml
+++ b/.github/workflows/rpm-verify.yml
@@ -1,0 +1,149 @@
+name: Verify RPM Packages
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  workflow_dispatch:
+
+jobs:
+  rpm-verify:
+    name: rpm-${{ matrix.target }}
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.title, '[skip ci]')
+    env:
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            rpm_arch: x86_64
+          - target: aarch64-unknown-linux-musl
+            rpm_arch: aarch64
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set envs
+        run: |
+          echo "PROJECT_VERSION=$(sed -n 's/^version = \"\(.*\)\"/\1/p' Cargo.toml | head -n1)" >> $GITHUB_ENV
+          echo "PROJECT_NAME=$(sed -n 's/^name = \"\(.*\)\"/\1/p' Cargo.toml | head -n1)" >> $GITHUB_ENV
+          echo "PROJECT_MAINTAINER=$(sed -n 's/^authors = \[\"\(.*\)\"\]/\1/p' Cargo.toml)" >> $GITHUB_ENV
+          echo "PROJECT_HOMEPAGE=$(sed -n 's/^homepage = \"\(.*\)\"/\1/p' Cargo.toml)" >> $GITHUB_ENV
+
+      - name: Install prerequisites
+        shell: bash
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install musl-tools qemu-user-static
+          if [[ "${{ matrix.target }}" =~ ^aarch64-unknown-linux ]]; then
+            sudo apt-get -y install gcc-aarch64-linux-gnu
+            mkdir -p $HOME/.cargo
+            echo "[target.aarch64-unknown-linux-musl]" >> $HOME/.cargo/config
+            echo 'linker = "aarch64-linux-gnu-gcc"' >> $HOME/.cargo/config
+          fi
+
+      - name: Build the release target
+        shell: bash
+        run: |
+          rustup target add ${{ matrix.target }}
+          case ${{ matrix.target }} in
+            x86_64-unknown-linux-musl) CFLAGS="-fPIE" CC="musl-gcc -static" cargo build --verbose --features oniguruma --release --target ${{ matrix.target }} ;;
+            aarch64-unknown-linux-musl) CC="aarch64-linux-gnu-gcc -specs /usr/lib/x86_64-linux-musl/musl-gcc.specs" cargo build --verbose --features oniguruma --release --target ${{ matrix.target }} ;;
+          esac
+
+      - name: Pack files for RPM
+        shell: bash
+        run: |
+          mkdir -p package/bin
+          mkdir -p package/man
+          mkdir -p package/doc
+          cp README.md package/doc
+          cp LICENSE package/doc
+          cp target/${{ matrix.target }}/release/teip package/bin
+          cp man/teip.1 package/man
+          cp -r completion package/
+
+      - name: Build RPM
+        shell: bash
+        run: |
+          RPM_BUILD=rpmbuild
+          RPM_PACK=teip-${PROJECT_VERSION}
+          BIN_NAME=teip-${PROJECT_VERSION}.${{ matrix.target }}.rpm
+
+          cp -al "package/" "${RPM_PACK}/"
+          tar zcvf "${RPM_PACK}.tar.gz" -C "$PWD" "${RPM_PACK}"
+          mkdir -p "${RPM_BUILD}/SOURCES"
+          mkdir -p "${RPM_BUILD}/SPECS"
+          cp "${RPM_PACK}.tar.gz" "${RPM_BUILD}/SOURCES"
+
+          cat > "${RPM_BUILD}/SPECS/template.spec" <<EOF
+          %global _binary_filedigest_algorithm 10
+          %global _source_filedigest_algorithm 10
+          Name:       ${PROJECT_NAME}
+          Summary:    Masking tape to help commands "do one thing well"
+          Version:    ${PROJECT_VERSION}
+          Group:      Applications
+          License:    MIT
+          Release:    1
+          BuildArch:  ${{ matrix.rpm_arch }}
+          URL:        ${PROJECT_HOMEPAGE}
+          Source:     ${RPM_PACK}.tar.gz
+          Vendor:     Yasuhiro Yamada <yamada@gr3.ie>
+          Provides:   ${PROJECT_NAME}
+          BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+          %description
+          Masking tape to help commands "do one thing well"
+          Bypassing a partial range of standard input to any command
+          whatever you want
+          %prep
+          %setup
+          %install
+          install -d -m 0755 %{buildroot}%{_bindir}
+          install -d -m 0755 %{buildroot}%{_mandir}/man1
+          install -d -m 0755 %{buildroot}%{_docdir}/%{name}/
+          install -d -m 0755 %{buildroot}%{_datadir}/zsh/site-functions
+          install -d -m 0755 %{buildroot}%{_datadir}/fish/completions
+          install -d -m 0755 %{buildroot}%{_datadir}/bash-completion/completions/
+          %{__cp} -a bin/* %{buildroot}%{_bindir}/
+          %{__cp} -a man/*.1 %{buildroot}%{_mandir}/man1/
+          %{__cp} -a doc/README.md %{buildroot}%{_docdir}/%{name}/
+          %{__cp} -a doc/LICENSE %{buildroot}%{_docdir}/%{name}/
+          %{__cp} -a completion/zsh/* %{buildroot}%{_datadir}/zsh/site-functions/
+          %{__cp} -a completion/fish/* %{buildroot}%{_datadir}/fish/completions/
+          %{__cp} -a completion/bash/* %{buildroot}%{_datadir}/bash-completion/completions/
+          %files
+          %attr(0644, root, root) %{_mandir}/man1/*
+          %attr(0755, root, root) %{_bindir}/*
+          %attr(0644, root, root) %{_datadir}/zsh/site-functions/*
+          %attr(0644, root, root) %{_datadir}/fish/completions/*
+          %attr(0644, root, root) %{_datadir}/bash-completion/completions/*
+          %attr(0644, root, root) %doc %{_docdir}/%{name}/README.md
+          %attr(0644, root, root) %doc %{_docdir}/%{name}/LICENSE
+          %clean
+          %{__rm} -rf %{buildroot}
+          EOF
+
+          docker build -t ${{ matrix.rpm_arch }}-rpm-builder -f .github/dockerfiles/Dockerfile.${{ matrix.rpm_arch }} .
+          sudo docker run --rm -v "$PWD/$RPM_BUILD":/root/rpmbuild ${{ matrix.rpm_arch }}-rpm-builder \
+            rpmbuild --undefine=_disable_source_fetch -ba /root/rpmbuild/SPECS/template.spec
+
+          sudo mv "$RPM_BUILD"/RPMS/"${{ matrix.rpm_arch }}"/teip-*.rpm "$BIN_NAME"
+          echo "BIN_NAME=$BIN_NAME" >> $GITHUB_ENV
+
+      - name: Upload RPM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpm-${{ matrix.target }}
+          path: ${{ env.BIN_NAME }}
+
+      - name: Verify RPM on Fedora 43
+        shell: bash
+        run: |
+          sudo docker run --rm -v "$PWD":/work -w /work fedora:43 sh -lc '
+            dnf install -y --nogpgcheck /work/'"$BIN_NAME"'
+            rpm -Kv /work/'"$BIN_NAME"'
+          '

--- a/.github/workflows/rpm-verify.yml
+++ b/.github/workflows/rpm-verify.yml
@@ -127,8 +127,12 @@ jobs:
           %{__rm} -rf %{buildroot}
           EOF
 
-          docker build -t ${{ matrix.rpm_arch }}-rpm-builder -f .github/dockerfiles/Dockerfile.${{ matrix.rpm_arch }} .
-          sudo docker run --rm -v "$PWD/$RPM_BUILD":/root/rpmbuild ${{ matrix.rpm_arch }}-rpm-builder \
+          DOCKER_PLATFORM=
+          if [[ "${{ matrix.rpm_arch }}" == "aarch64" ]]; then
+            DOCKER_PLATFORM="--platform linux/arm64"
+          fi
+          docker build ${DOCKER_PLATFORM} -t ${{ matrix.rpm_arch }}-rpm-builder -f .github/dockerfiles/Dockerfile.${{ matrix.rpm_arch }} .
+          sudo docker run ${DOCKER_PLATFORM} --rm -v "$PWD/$RPM_BUILD":/root/rpmbuild ${{ matrix.rpm_arch }}-rpm-builder \
             rpmbuild --undefine=_disable_source_fetch -ba /root/rpmbuild/SPECS/template.spec
 
           sudo mv "$RPM_BUILD"/RPMS/"${{ matrix.rpm_arch }}"/teip-*.rpm "$BIN_NAME"


### PR DESCRIPTION
## Summary

This PR updates the RPM packaging pipeline to avoid `does not verify: no digest` failures on Fedora 43 and adds a PR-time verification workflow for RPM packages.

## Changes

- switch RPM builder images from CentOS 7 to AlmaLinux 9
- set RPM file digest macros to SHA-512 in the generated spec file
- verify built RPMs on Fedora 43 in the release workflow
- add a dedicated PR workflow to build and verify RPM packages before merge
- fix aarch64 RPM builder image selection by using AlmaLinux multi-arch images with `--platform linux/arm64`

## Why

Issue #74 reports that the current RPM package fails to install on Fedora 43 with:

`package ... does not verify: no digest`

The current RPMs are built with an outdated CentOS 7-based environment. This PR modernizes the RPM build environment and explicitly configures stronger file digest settings so we can validate compatibility before release.

Closes #74

## Validation

- release workflow now verifies RPM installation on Fedora 43
- PR workflow builds RPMs for:
  - `x86_64-unknown-linux-musl`
  - `aarch64-unknown-linux-musl`
- PR workflow runs:
  - `dnf install --nogpgcheck <rpm>`
  - `rpm -Kv <rpm>`

## Notes

- commits were created without GPG signing in the local environment because local `git commit` signing failed